### PR TITLE
Fix 90 update invite endpoints for status filtering

### DIFF
--- a/endor/doc/api_data.js
+++ b/endor/doc/api_data.js
@@ -868,6 +868,13 @@ define({ "api": [
             "optional": false,
             "field": "id",
             "description": "<p>the id of the project to get contributor invites to</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": true,
+            "field": "status",
+            "description": "<p>the status to filter results by. May be one of the following: <code>['open','accepted','declined','rescinded','expired']</code></p>"
           }
         ]
       }

--- a/endor/doc/api_data.js
+++ b/endor/doc/api_data.js
@@ -1024,6 +1024,19 @@ define({ "api": [
         "name": "authenticated user"
       }
     ],
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": true,
+            "field": "status",
+            "description": "<p>the status to filter results by. May be one of the following: <code>['open','accepted','declined','rescinded','expired']</code></p>"
+          }
+        ]
+      }
+    },
     "success": {
       "fields": {
         "Success 200": [

--- a/endor/doc/api_data.json
+++ b/endor/doc/api_data.json
@@ -868,6 +868,13 @@
             "optional": false,
             "field": "id",
             "description": "<p>the id of the project to get contributor invites to</p>"
+          },
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": true,
+            "field": "status",
+            "description": "<p>the status to filter results by. May be one of the following: <code>['open','accepted','declined','rescinded','expired']</code></p>"
           }
         ]
       }

--- a/endor/doc/api_data.json
+++ b/endor/doc/api_data.json
@@ -1024,6 +1024,19 @@
         "name": "authenticated user"
       }
     ],
+    "parameter": {
+      "fields": {
+        "Parameter": [
+          {
+            "group": "Parameter",
+            "type": "String",
+            "optional": true,
+            "field": "status",
+            "description": "<p>the status to filter results by. May be one of the following: <code>['open','accepted','declined','rescinded','expired']</code></p>"
+          }
+        ]
+      }
+    },
     "success": {
       "fields": {
         "Success 200": [

--- a/endor/doc/api_project.js
+++ b/endor/doc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2018-01-24T02:10:25.363Z",
+    "time": "2018-01-24T21:35:05.072Z",
     "url": "http://apidocjs.com",
     "version": "0.17.6"
   }

--- a/endor/doc/api_project.js
+++ b/endor/doc/api_project.js
@@ -9,7 +9,7 @@ define({
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2018-01-24T21:35:05.072Z",
+    "time": "2018-01-24T22:13:49.192Z",
     "url": "http://apidocjs.com",
     "version": "0.17.6"
   }

--- a/endor/doc/api_project.json
+++ b/endor/doc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2018-01-24T21:35:05.072Z",
+    "time": "2018-01-24T22:13:49.192Z",
     "url": "http://apidocjs.com",
     "version": "0.17.6"
   }

--- a/endor/doc/api_project.json
+++ b/endor/doc/api_project.json
@@ -9,7 +9,7 @@
   "apidoc": "0.3.0",
   "generator": {
     "name": "apidoc",
-    "time": "2018-01-24T02:10:25.363Z",
+    "time": "2018-01-24T21:35:05.072Z",
     "url": "http://apidocjs.com",
     "version": "0.17.6"
   }

--- a/endor/src/controllers/invites.controller.js
+++ b/endor/src/controllers/invites.controller.js
@@ -37,7 +37,7 @@ export function setProjectService(newProjectService) {
  */
 export async function getInvitesByProjectId(req, res, next) {
   try {
-    const invites = await inviteService.getInvitesByProjectId(req.params.id);
+    const invites = await inviteService.getInvitesByProjectId(req.params.id, req.query.status);
     res.send(invites);
   } catch (error) {
     next(error);

--- a/endor/src/controllers/invites.controller.js
+++ b/endor/src/controllers/invites.controller.js
@@ -52,7 +52,7 @@ export async function getInvitesByProjectId(req, res, next) {
  */
 export async function getInvitesByUserId(req, res, next) {
   try {
-    const invites = await inviteService.getInvitesByUserId(req.params.id);
+    const invites = await inviteService.getInvitesByUserId(req.params.id, req.query.status);
     invites.other = req.params.other;
     res.send(invites);
   } catch (error) {

--- a/endor/src/index.js
+++ b/endor/src/index.js
@@ -23,7 +23,7 @@ import ClientService from './services/client.service';
 // eslint-disable-next-line import/no-unresolved
 import config from '../endorConfig.json';
 // eslint-disable-next-line import/no-unresolved
-import dbConfig from '../../dbConfig.json';
+import dbConfig from '../dbConfig.json';
 
 // Initialize the data model
 sequelize.initSequelize(

--- a/endor/src/routes/invites.routes.js
+++ b/endor/src/routes/invites.routes.js
@@ -56,6 +56,9 @@ router.get('/projects/:id/invites', authController.isAuthenticated, invitesContr
  *
  * @apiPermission authenticated user
  *
+ * @apiParam {String} [status] the status to filter results by.
+ *   May be one of the following: `['open','accepted','declined','rescinded','expired']`
+ *
  * @apiSuccess {Object[]} invites list of invites for authenticated user
  * @apiSuccessExample {json} Success-Response:
  * [

--- a/endor/src/routes/invites.routes.js
+++ b/endor/src/routes/invites.routes.js
@@ -29,6 +29,8 @@ export function setDependencies(inviteService, userService, projectService) {
  * @apiPermission project owner
  *
  * @apiParam {String} id the id of the project to get contributor invites to
+ * @apiParam {String} [status] the status to filter results by.
+ *   May be one of the following: `['open','accepted','declined','rescinded','expired']`
  *
  * @apiSuccess {Object[]} contributor invites to the project
  * @apiSuccessExample {json} Success-Response

--- a/endor/src/services/invites.service.js
+++ b/endor/src/services/invites.service.js
@@ -49,6 +49,17 @@ export default class InviteService {
     return errors;
   }
 
+  static attachStatusToFilter(status, filter) {
+    if (status) {
+      if (isValidInviteStatus(status)) {
+        // eslint-disable-next-line no-param-reassign
+        filter.status = status
+      } else {
+        throw new InvalidRequestException([new RequestParamError('status', getInvalidStatusMessage())]);
+      }
+    }
+  }
+
   /**
    * Gets a invite by the invite id
    * @param inviteId the invite id to find by
@@ -72,44 +83,31 @@ export default class InviteService {
   /**
    * Gets all invites for the given project
    * @param projectId the project id to find by
-   * @param statusFilter the status to filter invites by
+   * @param statusToFilterBy the status to filter invites by
    * @returns {Object} the invite that was found
    */
-  async getInvitesByProjectId(projectId, statusFilter) {
+  async getInvitesByProjectId(projectId, statusToFilterBy) {
     this.log.info(`InviteService: find invite with project id of ${projectId}`);
 
     const filter = { projectInvitedToId: projectId };
-    if (statusFilter) {
-      if (isValidInviteStatus(statusFilter)) {
-        filter.status = statusFilter
-      } else {
-        throw new InvalidRequestException([new RequestParamError('status', getInvalidStatusMessage())]);
-      }
-    }
+    InviteService.attachStatusToFilter(statusToFilterBy, filter);
 
-    return this.inviteRepository.findAll({
-      where: filter
-    });
+    return this.inviteRepository.findAll({ where: filter });
   }
 
   /**
    * Gets all invites for the given user
    * @param userId the user id to find by
+   * @param statusToFilterBy the status to filter invites by
    * @returns {Object} the invite that was found
    */
-  async getInvitesByUserId(userId) {
+  async getInvitesByUserId(userId, statusToFilterBy) {
     this.log.info(`InviteService: find invite with user id of ${userId}`);
-    const invitesFound = await this.inviteRepository.findAll({
-      where: {
-        userInvitedId: userId
-      }
-    });
 
-    if (invitesFound === null) {
-      throw new InviteNotFoundException(`Invites for user ${userId} could not be found.`);
-    }
+    const filter = { userInvitedId: userId };
+    InviteService.attachStatusToFilter(statusToFilterBy, filter);
 
-    return invitesFound;
+    return this.inviteRepository.findAll({ where: filter });
   }
 
   /**

--- a/endor/src/services/invites.service.js
+++ b/endor/src/services/invites.service.js
@@ -72,17 +72,24 @@ export default class InviteService {
   /**
    * Gets all invites for the given project
    * @param projectId the project id to find by
+   * @param statusFilter the status to filter invites by
    * @returns {Object} the invite that was found
    */
-  async getInvitesByProjectId(projectId) {
+  async getInvitesByProjectId(projectId, statusFilter) {
     this.log.info(`InviteService: find invite with project id of ${projectId}`);
-    const invitesFound = await this.inviteRepository.findAll({
-      where: {
-        projectInvitedToId: projectId
-      }
-    });
 
-    return invitesFound;
+    const filter = { projectInvitedToId: projectId };
+    if (statusFilter) {
+      if (isValidInviteStatus(statusFilter)) {
+        filter.status = statusFilter
+      } else {
+        throw new InvalidRequestException([new RequestParamError('status', getInvalidStatusMessage())]);
+      }
+    }
+
+    return this.inviteRepository.findAll({
+      where: filter
+    });
   }
 
   /**


### PR DESCRIPTION
#closes 90 : Update Invited endpoints for status filtering

The GET endpoints can have a ?status=open or similar query string to filter the invites that are returned to the user.