### PR TITLE
Fix 80 Email Invites

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ endor/dist/
 
 dbConfig.json
 endorConfig.json
+emailConfig.json
 
 .DS_Store
 */.DS_Store

--- a/endor/package-lock.json
+++ b/endor/package-lock.json
@@ -3365,6 +3365,11 @@
         "tar-pack": "3.4.1"
       }
     },
+    "nodemailer": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-4.4.2.tgz",
+      "integrity": "sha512-sstDxbCSPHDXrWRQhH++khr3yVU0CGvH2dCtAHOPQQ0lRR7xwq2txItEXckMpX481B/cN+0akER2bfExh7Gu/Q=="
+    },
     "nomnom": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/nomnom/-/nomnom-1.8.1.tgz",

--- a/endor/package.json
+++ b/endor/package.json
@@ -54,6 +54,7 @@
     "mocha": "3.5.3",
     "morgan": "1.9.0",
     "mysql2": "^1.5.1",
+    "nodemailer": "^4.4.2",
     "oauth2orize": "^1.11.0",
     "passport": "0.4.0",
     "passport-http": "^0.3.0",

--- a/endor/src/controllers/invites.controller.js
+++ b/endor/src/controllers/invites.controller.js
@@ -4,6 +4,7 @@ import { InviteStatus } from '../db/sequelize';
 let inviteService = {};
 let userService = {};
 let projectService = {};
+let emailService = {};
 
 /**
  * Sets the invite service for the controller
@@ -27,6 +28,14 @@ export function setUserService(newUserService) {
  */
 export function setProjectService(newProjectService) {
   projectService = newProjectService;
+}
+
+/**
+ * Sets the email service for the controller
+ * @param newEmailService the new email service
+ */
+export function setEmailService(newEmailService) {
+  emailService = newEmailService;
 }
 
 /**
@@ -85,14 +94,17 @@ export async function addInviteToProject(req, res, next) {
     const daysFromCreationUntilExpiration = req.body.daysFromCreationUntilExpiration;
 
     // Validate that the user and project actually exist
-    await projectService.getProjectById(projectId);
-    await userService.getUserByIdOrUsername(userIdOrUsername);
+    const project = await projectService.getProjectById(projectId);
+    const user = await userService.getUserByIdOrUsername(userIdOrUsername);
 
     const invite = await inviteService.createInvite(
       projectId,
       userIdOrUsername,
       daysFromCreationUntilExpiration
     );
+
+    await emailService.emailInvite(user, project, invite);
+
     res.status(201).send(invite);
   } catch (error) {
     next(error);

--- a/endor/src/db/sequelize.js
+++ b/endor/src/db/sequelize.js
@@ -26,6 +26,7 @@ module.exports.DataTypes = Sequelize.DataTypes;
 
 let initialized = false;
 
+module.exports.isInitialized = () => initialized;
 module.exports.initSequelize = (database, username, password, options) => {
   if (initialized) {
     getActiveLogger().warn('Sequelize can only be initialized once!');

--- a/endor/src/index.js
+++ b/endor/src/index.js
@@ -20,10 +20,25 @@ import * as owners from './routes/owners.routes';
 import UserService from './services/users.service';
 import AuthService from './services/auth.service';
 import ClientService from './services/client.service';
+import EmailService from './services/email.service';
 // eslint-disable-next-line import/no-unresolved
 import config from '../endorConfig.json';
 // eslint-disable-next-line import/no-unresolved
 import dbConfig from '../dbConfig.json';
+// eslint-disable-next-line import/no-unresolved
+import emailConfig from '../emailConfig.json';
+
+// TODO: Set email from address and email transport options for production
+const emailFromAddress = '"Hammer-IO" <hello@hammer-io.github.io>';
+const emailTransportOptions = {
+  host: 'smtp.ethereal.email',
+  port: 587,
+  secure: false, // true for 465, false for other ports
+  auth: {
+    user: emailConfig.user,
+    pass: emailConfig.pass
+  }
+};
 
 // Initialize the data model
 sequelize.initSequelize(
@@ -54,13 +69,14 @@ const projectService = new ProjectService(sequelize.Project, userService, getAct
 const inviteService = new InviteService(sequelize.Invite, getActiveLogger());
 const authService = new AuthService(sequelize.Token, sequelize.AccessCode, getActiveLogger());
 const clientService = new ClientService(sequelize.Client, getActiveLogger());
+const emailService = new EmailService(emailFromAddress, getActiveLogger(), emailTransportOptions);
 auth.setDependencies(userService, clientService, authService);
 client.setDependencies(userService, clientService, authService);
 projects.setProjectService(projectService);
 users.setDependencies(userService);
 contributors.setDependencies(projectService);
 owners.setDependencies(projectService);
-invites.setDependencies(inviteService, userService, projectService);
+invites.setDependencies(inviteService, userService, projectService, emailService);
 // end dependency injections //
 
 // API ENDPOINTS //

--- a/endor/src/middlewares/invites.middleware.js
+++ b/endor/src/middlewares/invites.middleware.js
@@ -18,7 +18,7 @@ export function isNonNegativeInteger(value) {
  */
 export function checkForNonNegativeInteger(req, res, next) {
   const value = req.body.daysFromCreationUntilExpiration;
-  if (!isNonNegativeInteger(value)) {
+  if (value && !isNonNegativeInteger(value)) {
     throw new RequestParamError('daysFromCreationUntilExpiration', 'Must be a non-negative integer.');
   }
   next();

--- a/endor/src/routes/invites.routes.js
+++ b/endor/src/routes/invites.routes.js
@@ -14,10 +14,11 @@ export const router = express.Router();
  * @param userService the user service dependency
  * @param projectService the project service dependency
  */
-export function setDependencies(inviteService, userService, projectService) {
+export function setDependencies(inviteService, userService, projectService, emailService) {
   invitesController.setInviteService(inviteService);
   invitesController.setUserService(userService);
   invitesController.setProjectService(projectService);
+  invitesController.setEmailService(emailService);
 }
 
 /**

--- a/endor/src/services/email.service.js
+++ b/endor/src/services/email.service.js
@@ -1,0 +1,31 @@
+import nodemailer from 'nodemailer';
+
+
+export default class EmailService {
+  constructor(fromAddress, logger, transportOptions) {
+    this.from = fromAddress;
+    this.log = logger;
+    this.transporter = nodemailer.createTransport(transportOptions);
+  }
+
+  async emailInvite(user, project, invite) {
+    return new Promise((resolve, reject) => {
+      const mailOptions = {
+        from: this.from,
+        to: user.email,
+        subject: `Invitation to contribute to project ${project.projectName}`,
+        text: `Hello ${user.firstName}! You've been invited to contribute to project ${project.projectName}. Please visit the following link to accept or decline this invitation: https://hammer-io.github.io/api/v1/invites/${invite.id}`, // plain text body
+        html: `<h2>Hello ${user.firstName}!</h2><p>You've been invited to contribute to project ${project.projectName}. Please visit the following link to accept or decline this invitation: <a href="https://hammer-io.github.io/api/v1/invites/${invite.id}" target="_blank">https://hammer-io.github.io/api/v1/invites/${invite.id}</a></p>` // html body
+      };
+
+      // send mail with defined transport object
+      return this.transporter.sendMail(mailOptions, (error, info) => {
+        if (error) {
+          reject(error);
+        }
+        this.log.info(`Message sent: ${info.messageId}`);
+        resolve(info);
+      });
+    });
+  }
+}

--- a/endor/test/auth.service.test.js
+++ b/endor/test/auth.service.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 // Using Expect style
-const sequalize = require('../src/db/sequelize');
+const sequelize = require('../src/db/sequelize');
 import { defineTables } from '../src/db/init_database';
 import {
   populateClients,
@@ -13,16 +13,18 @@ import AuthService from './../src/services/auth.service';
 import { getMockLogger } from './mockLogger';
 
 // Initialize Sequelize with sqlite for testing
-sequalize.initSequelize(
-  'database',
-  'root',
-  'root', {
-    dialect: 'sqlite',
-    logging: false
-  }
-);
+if (!sequelize.isInitialized()) {
+  sequelize.initSequelize(
+    'database',
+    'root',
+    'root', {
+      dialect: 'sqlite',
+      logging: false
+    }
+  );
+}
 
-const authService = new AuthService(sequalize.Token, sequalize.AccessCode, getMockLogger());
+const authService = new AuthService(sequelize.Token, sequelize.AccessCode, getMockLogger());
 
 
 describe('Testing Auth Service', () => {

--- a/endor/test/client.service.test.js
+++ b/endor/test/client.service.test.js
@@ -8,14 +8,16 @@ import ClientService from './../src/services/client.service';
 import { getMockLogger } from './mockLogger';
 
 // Initialize Sequelize with sqlite for testing
-sequelize.initSequelize(
-  'database',
-  'root',
-  'root', {
-    dialect: 'sqlite',
-    logging: false
-  }
-);
+if (!sequelize.isInitialized()) {
+  sequelize.initSequelize(
+    'database',
+    'root',
+    'root', {
+      dialect: 'sqlite',
+      logging: false
+    }
+  );
+}
 
 const clientService = new ClientService(sequelize.Client, getMockLogger());
 

--- a/endor/test/email.service.test.js
+++ b/endor/test/email.service.test.js
@@ -1,0 +1,66 @@
+import { expect } from 'chai';
+import nodemailer from 'nodemailer';
+
+import { defineTables } from '../src/db/init_database';
+import { populateUsers, populateProjects, populateInvites } from '../src/db/import_test_data';
+
+// Using Expect style
+const sequelize = require('../src/db/sequelize');
+
+import * as emailUtil from './util/email';
+import EmailService from '../src/services/email.service';
+import { getMockLogger } from './mockLogger';
+
+const InviteStatus = sequelize.InviteStatus;
+
+// Initialize Sequelize with sqlite for testing
+if (!sequelize.isInitialized()) {
+  sequelize.initSequelize(
+    'database',
+    'root',
+    'root', {
+      dialect: 'sqlite',
+      logging: false
+    }
+  );
+}
+
+let emailService = null;
+
+describe('Testing Email Service', () => {
+  before(async () => {
+    try {
+      await defineTables();
+      await populateUsers();
+      await populateProjects();
+      await populateInvites();
+      const transportOptions = await emailUtil.getTestTransportOptions();
+      emailService = new EmailService('"Holmgang" <holmgang@hammer-io.github.io>', getMockLogger(), transportOptions);
+    } catch (err) {
+      console.log('ERROR: Something went wrong setting up the email service!');
+      console.log(err);
+      expect.fail();
+    }
+  });
+
+  describe('Send email', async () => {
+    it('should send an email', async () => {
+      const invite = await sequelize.Invite.findOne(  {where: { status: InviteStatus.OPEN         }});
+      const user = await sequelize.User.findOne(      {where: {     id: invite.userInvitedId      }});
+      const project = await sequelize.Project.findOne({where: {     id: invite.projectInvitedToId }});
+
+      const results = await emailService.emailInvite(user, project, invite);
+
+      // Show the preview URL (viewable only if you're online)
+      const previewUrl = nodemailer.getTestMessageUrl(results);
+      console.log(`      Preview URL: ${previewUrl}`);
+
+      // Verify the results of the method call
+      expect(Array.isArray(results.accepted)).to.equal(true);
+      expect(results.accepted.length).to.equal(1);
+      expect(results.accepted[0]).to.equal(user.email);
+      expect(Array.isArray(results.rejected)).to.equal(true);
+      expect(results.rejected.length).to.equal(0);
+    }).timeout(10000);
+  });
+});

--- a/endor/test/projects.service.test.js
+++ b/endor/test/projects.service.test.js
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 // Using Expect style
-const sequalize = require('../src/db/sequelize');
+const sequelize = require('../src/db/sequelize');
 
 import UserService from './../src/services/users.service';
 import { getMockLogger } from './mockLogger';
@@ -9,17 +9,19 @@ import { defineTables, populateTools } from '../src/db/init_database';
 import { populateUsers, populateProjects } from '../src/db/import_test_data';
 
 // Initialize Sequelize with sqlite for testing
-sequalize.initSequelize(
-  'database',
-  'root',
-  'root', {
-    dialect: 'sqlite',
-    logging: false
-  }
-);
+if (!sequelize.isInitialized()) {
+  sequelize.initSequelize(
+    'database',
+    'root',
+    'root', {
+      dialect: 'sqlite',
+      logging: false
+    }
+  );
+}
 
-const userService = new UserService(sequalize.User, sequalize.Credentials, getMockLogger());
-const projectService = new ProjectService(sequalize.Project, userService, getMockLogger());
+const userService = new UserService(sequelize.User, sequelize.Credentials, getMockLogger());
+const projectService = new ProjectService(sequelize.Project, userService, getMockLogger());
 
 describe('Testing Project Service', async () => {
   beforeEach(async () => {

--- a/endor/test/users.service.test.js
+++ b/endor/test/users.service.test.js
@@ -2,22 +2,24 @@ import { expect } from 'chai';
 import { defineTables } from '../src/db/init_database';
 import { populateUsers } from '../src/db/import_test_data';
 // Using Expect style
-const sequalize = require('../src/db/sequelize');
+const sequelize = require('../src/db/sequelize');
 
 import UserService from './../src/services/users.service';
 import { getMockLogger } from './mockLogger';
 
 // Initialize Sequelize with sqlite for testing
-sequalize.initSequelize(
-  'database',
-  'root',
-  'root', {
-    dialect: 'sqlite',
-    logging: false
-  }
-);
+if (!sequelize.isInitialized()) {
+  sequelize.initSequelize(
+    'database',
+    'root',
+    'root', {
+      dialect: 'sqlite',
+      logging: false
+    }
+  );
+}
 
-const userService = new UserService(sequalize.User, sequalize.Credentials, getMockLogger());
+const userService = new UserService(sequelize.User, sequelize.Credentials, getMockLogger());
 
 describe('Testing User Service', () => {
   beforeEach(async () => {

--- a/endor/test/util/email.js
+++ b/endor/test/util/email.js
@@ -1,0 +1,59 @@
+import nodemailer from 'nodemailer';
+import path from 'path';
+import * as fileUtil from './file';
+
+const emailConfigFilename = '../../emailConfig.json';
+
+/**
+ * Generate test SMTP service account from ethereal.email
+ * This account information is written to './endor/emailConfig.json' for use
+ * in running additional tests and viewing email results at https://ethereal.email/
+ * @returns {Promise.Object} the account information for the new ethereal account
+ */
+async function setupTestAccount() {
+  return new Promise((resolve, reject) => {
+    nodemailer.createTestAccount((err, account) => {
+      if (err) {
+        console.error('Failed to create a testing account. ' + err.message);
+        reject(err);
+      }
+
+      const completePath = path.join(__dirname, '/', emailConfigFilename);
+      console.log(`Credentials obtained.\n  Writing to '${completePath}'.\n  This should NOT be committed to the repository!`);
+      fileUtil.writeFile(emailConfigFilename, JSON.stringify(account));
+
+      // After writing the file, return the new account information
+      resolve(account);
+    });
+  });
+}
+
+async function getEmailAccount() {
+  try {
+    const accountString = fileUtil.readFile(emailConfigFilename);
+    const account = JSON.parse(accountString);
+    if (typeof account.user === 'undefined') {
+      return setupTestAccount();
+    }
+    return account;
+  } catch (_) {
+    // File doesn't exist, so create a new account
+    return setupTestAccount();
+  }
+}
+
+/**
+ * Create reusable transporter object using the default SMTP transport
+ */
+export async function getTestTransportOptions() {
+  const account = await getEmailAccount();
+  return {
+    host: 'smtp.ethereal.email',
+    port: 587,
+    secure: false, // true for 465, false for other ports
+    auth: {
+      user: account.user, // generated ethereal user
+      pass: account.pass  // generated ethereal password
+    }
+  };
+}

--- a/endor/test/util/file.js
+++ b/endor/test/util/file.js
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import path from 'path';
+
+import { getMockLogger } from '../mockLogger';
+
+const log = getMockLogger();
+
+/**
+ * Reads the file at the path given.
+ * @param filePath
+ * @returns {*}
+ */
+export function readFile(filePath) {
+  const completePath = path.join(__dirname, '/', filePath);
+  log.verbose(`Reading file: '${completePath}'`);
+  try {
+    return fs.readFileSync(completePath, 'utf-8');
+  } catch (e) {
+    log.debug(e.message);
+    throw new Error(`Failed to read file '${completePath}'!`);
+  }
+}
+
+
+/**
+ * Write to the given filePath with the contents of a file.  The given errMsg should be a constant.
+ *
+ * @param filePath
+ * @param fileContents
+ * @returns {*}
+ */
+export function writeFile(filePath, fileContents) {
+  const completePath = path.join(__dirname, '/', filePath);
+  log.verbose(`Writing file: '${completePath}'`);
+  try {
+    return fs.writeFileSync(completePath, fileContents);
+  } catch (e) {
+    log.debug(e.message);
+    throw new Error(`Failed to write '${completePath}'!`);
+  }
+}


### PR DESCRIPTION
closes #80 : Emailing the contributor invitations

- Provides an email service
- Runs tests against that service
- Sets up the test accounts for previewing emails sent to fake users
- When you create a new invite, it automatically sends an email to the user invited
