### PR TITLE
Fixed some console warnings

### DIFF
--- a/src/components/project/monitoring/GraphHeartbeats.js
+++ b/src/components/project/monitoring/GraphHeartbeats.js
@@ -98,6 +98,7 @@ class GraphHeartbeats extends React.Component {
         ...newState
       }
     }
+    return null
   }
 
   constructor(props) {
@@ -134,6 +135,7 @@ class GraphHeartbeats extends React.Component {
               {
                 summaryData.map((entry, index) => (
                   <Cell
+                    key={`GraphHeartbeat.${entry.id}`}
                     cursor="pointer"
                     stroke={index === activeIndex ? Theme.colors.black : ''}
                     strokeWidth={3}

--- a/src/components/project/monitoring/GraphUrls.js
+++ b/src/components/project/monitoring/GraphUrls.js
@@ -38,6 +38,7 @@ class GraphUrls extends React.Component {
         ...newState
       }
     }
+    return null
   }
 
   constructor(props) {

--- a/src/components/project/monitoring/HttpRequestWidget.js
+++ b/src/components/project/monitoring/HttpRequestWidget.js
@@ -44,6 +44,7 @@ class HttpRequestWidget extends React.PureComponent {
         ...newState
       }
     }
+    return null
   }
 
   constructor(props) {

--- a/src/components/project/overview/ProjectDescription.js
+++ b/src/components/project/overview/ProjectDescription.js
@@ -13,6 +13,9 @@ const styles = {
 
 class ProjectDescription extends React.PureComponent {
   render() {
+    if (!this.props.content) {
+      return null
+    }
     return (
       <Card style={styles.container}>
         <CardText>
@@ -23,8 +26,12 @@ class ProjectDescription extends React.PureComponent {
   }
 }
 
+ProjectDescription.defaultProps = {
+  content: null
+}
+
 ProjectDescription.propTypes = {
-  content: PropTypes.string.isRequired
+  content: PropTypes.string
 }
 
 export default ProjectDescription

--- a/src/components/project/settings/APIKey.js
+++ b/src/components/project/settings/APIKey.js
@@ -68,8 +68,12 @@ class APIKey extends React.PureComponent {
   }
 }
 
+APIKey.defaultProps = {
+  apiKey: null
+}
+
 APIKey.propTypes = {
-  apiKey: PropTypes.string.isRequired
+  apiKey: PropTypes.string
 }
 
 export default APIKey


### PR DESCRIPTION
Closes #189 

Warnings I couldn't/didn't fix:

```
// Will be fixed in the next version of react I believe
Warning: Failed prop type: Invalid prop `path` of type `array` supplied to `Route`, expected `string`.
    in Route (created by Root)
    in Root

// Looked into it, but couldn't find what was causing it. Since material-ui has v1 coming out soon (it's currently in beta), I figured this will fix itself when we eventually update to v1.
Warning: Material-UI: You cannot call prepareStyles() on the same style object more than once.

// Introduced by the FeatureDiscovery component. Didn't want to mess with it though.
Warning: unmountComponentAtNode(): The node you're attempting to unmount was rendered by React and is not a top-level container. Instead, have the parent component update its state and rerender in order to remove this component.
```

Errors I couldn't/didn't fix:

```
// Comes up on the Project Details page
error: Object {  }
message: "OAuth2 authentication requires a token or key & secret to be set"

// Comes up on the Project Details page
error: Object {  }
message: "Cannot read property 'replace' of null"

// Comes up when trying to create a new project (creation fails)
error: Object {  }
message: "Only HTTP(S) protocols are supported"
Unhandled promise rejection 
TypeError: project is null
Stack trace:
_callee2$@http://localhost:8080/bundle.js:195286:17
tryCatch@http://localhost:8080/bundle.js:93780:37
invoke@http://localhost:8080/bundle.js:94018:22
defineIteratorMethods/</prototype[method]@http://localhost:8080/bundle.js:93832:16
step@http://localhost:8080/bundle.js:194910:183
step/<@http://localhost:8080/bundle.js:194910:361
run@http://localhost:8080/bundle.js:91787:22
notify/<@http://localhost:8080/bundle.js:91800:30
flush@http://localhost:8080/bundle.js:42626:9

// Shows up on login page (doesn't actually say superlongstring, fyi)
error: Object { message: "Token <superlongstring> not found", type: "Forbidden", status: 403 }
message: "Token <superlongstring> not found"
```
